### PR TITLE
Respect preferred model download directories

### DIFF
--- a/apply_whisper.py
+++ b/apply_whisper.py
@@ -112,7 +112,33 @@ class ApplyWhisperNode:
         cache_key = model
         if cache_key not in WHISPER_PATCHER_CACHE:
             load_device = mm.get_torch_device()
-            download_root = os.path.join(folder_paths.models_dir, WHISPER_MODEL_SUBDIR)
+            # Determine appropriate location to download models
+            download_root = None
+    
+            # Option A: user defines a direct key to the whisper folder (recommended)
+            for key in ("stt_whisper", "whisper"):
+             try:
+                paths = folder_paths.get_folder_paths(key)
+                if paths:
+                    download_root = paths[0]
+                    break
+             except Exception:
+                pass
+
+            # Option B: user defines "stt" as a base folder and we use /whisper under it
+            if download_root is None:
+             try:
+                paths = folder_paths.get_folder_paths("stt")
+                if paths:
+                    download_root = os.path.join(paths[0], "whisper")
+             except Exception:
+                pass
+
+            # Fallback: ComfyUI default location
+            if download_root is None:
+             download_root = os.path.join(folder_paths.models_dir, WHISPER_MODEL_SUBDIR)
+
+            os.makedirs(download_root, exist_ok=True)
             logger.info(f"Creating Whisper ModelPatcher for {model} on device {load_device}")
             
             model_wrapper = WhisperModelWrapper(model, download_root)


### PR DESCRIPTION
As referenced in https://github.com/yuvraj108c/ComfyUI-Whisper/issues/36 , this PR respects alternative model download folders the user may have specified in ComfyUI's extra_model_paths.yaml

- If `whisper` or `stt_whisper` are specified in `extra_model_paths.yaml`, then models will be downloaded to, and loaded from that directory.
- Else, if `stt` is specified, models will be downloaded to, and loaded from the "whisper" subfolder of that directory (as specified by WHISPER_MODEL_SUBDIR)
- Else, models are downloaded to, and loaded from stt/whisper subfolder of ComfyUI models directory (existing behaviour)