### PR TITLE
Add option to choose the folder where the .srt file will be saved

### DIFF
--- a/save_srt.py
+++ b/save_srt.py
@@ -8,9 +8,12 @@ class SaveSRTNode:
     @classmethod
     def INPUT_TYPES(s):
         return {
-            "required": { 
-                "alignment" : ("whisper_alignment",),
-                "name": ("STRING",{"default": "subtitles"}),
+            "required": {
+                "alignment": ("whisper_alignment",),
+                "name": ("STRING", {"default": "subtitles"}),
+            },
+            "optional": {
+                "subfolder": ("STRING", {"default": "srt"}),
             }
         }
 
@@ -50,13 +53,11 @@ class SaveSRTNode:
 
         return srt_content
 
-    def save_srt(self, alignment, name):
+    def save_srt(self, alignment, name, subfolder="srt"):
+        save_dir = os.path.join(folder_paths.get_output_directory(), subfolder)
+        os.makedirs(save_dir, exist_ok=True)
 
-        subfolder = "srt"
-        output_dir = os.path.join(folder_paths.get_output_directory(), subfolder)
-        os.makedirs(output_dir,exist_ok=True)
-
-        srt_save_path = os.path.join(output_dir, name) + ".srt"
+        srt_save_path = os.path.join(save_dir, name) + ".srt"
         srt_content = self.json_to_srt(alignment)
 
         with open(srt_save_path, 'w', encoding='utf-8') as f:


### PR DESCRIPTION
## Description

Added an optional **subfolder** parameter to the `SAVE_SRT` node.

### Default behavior

The parameter defaults to `srt`, preserving the existing behavior.

### Custom output location

You can customize where the `.srt` file is saved by:

* Passing an empty string (`""`) to save it directly in the output directory.
* Specifying a relative subfolder path, for example:

```text
some_folder/another_folder/one_more_folder
```

This will save the `.srt` file inside the specified subfolder structure under the output directory instead of the hardcoded location in the code.
